### PR TITLE
Add I18n/L10n support for text: auth by login/password

### DIFF
--- a/app/overrides/account/login.rb
+++ b/app/overrides/account/login.rb
@@ -5,7 +5,7 @@ Deface::Override.new :virtual_path  => 'account/login',
 <% if RedmineOmniauthCas.enabled? && RedmineOmniauthCas.cas_server.present? %>
 <div style="text-align:center; margin:15px">
   <em class=info>
-    <%= link_to_function "ou s'authentifier par login / mot de passe", "$('#login-form-container').show(); $(this).hide();" %>
+    <%= link_to_function l(:text_authenticate_by_login_password), "$('#login-form-container').show(); $(this).hide();" %>
   </em>
 </div>
 <div id="login-form-container" style="display:none">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
   label_cas_server: CAS server URL
   label_cas_service_validate_url: CAS validation URL (if different)
   label_replace_redmine_login: Replace Redmine login page
+  text_authenticate_by_login_password: or authenticate by login / password
   text_full_logout_proposal: You may want to %{value} before trying an other username.
   text_logout_from_cas: logout from CAS
   notice_cas_yaml_config_active: "CAS server settings are configured via YAML file:"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,6 +5,7 @@ fr:
   label_cas_server: Adresse du serveur CAS
   label_cas_service_validate_url: Adresse de validation CAS (si différente)
   label_replace_redmine_login: Remplacer la page de login de Redmine
+  text_authenticate_by_login_password: ou s'authentifier par login / mot de passe
   text_full_logout_proposal: Peut-être voulez-vous vous %{value} avant d'essayer un autre nom d'utilisateur ?
   text_logout_from_cas: déconnecter de CAS
   notice_cas_yaml_config_active: "Les paramètres du serveur CAS sont configurés via ce fichier :"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -5,6 +5,7 @@ pt-BR:
   label_cas_server: URL do servidor CAS
   label_cas_service_validate_url: URL de validação do CAS (se diferente)
   label_replace_redmine_login: Substituir página de login do Redmine
+  text_authenticate_by_login_password: ou autenticar por login/senha
   text_full_logout_proposal: Você precisa acessar %{value} antes de tentar logar com outro usuário.
   text_logout_from_cas: logout do CAS
   error_cas_no_ticket: Ticket do CAS não recebido no callback. Tente autenticar novamente.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -5,6 +5,7 @@ zh:
   label_cas_server: CAS 服务器地址
   label_cas_service_validate_url: CAS 验证地址 (如果不同)
   label_replace_redmine_login: 替换 Redmine 登录页
+  text_authenticate_by_login_password: 使用 登录名/密码 进行身份验证
   text_full_logout_proposal: 在尝试其他用户名之前，您可能需要 %{value}。
   text_logout_from_cas: 从 CAS 登出
   error_cas_no_ticket: 回调期间未找到 CAS ticket。请尝试再次进行身份验证


### PR DESCRIPTION
As title.

L10n note:
* fr: copy from exist text
* zh: my native language
* en: translated by me
* pt-BR: translated by Google Translate